### PR TITLE
feat: Claude用のlabeler設定を追加

### DIFF
--- a/.github/configs/labeler.yml
+++ b/.github/configs/labeler.yml
@@ -1,3 +1,6 @@
 github-action:
   - changed-files:
       - any-glob-to-any-file: '.github/**'
+claude:
+  - changed-files:
+      - any-glob-to-any-file: '.claude/**'


### PR DESCRIPTION
## 概要
GitHub ActionsのPR Labelerに、Claude関連ファイルを自動でラベル付けする設定を追加しました。

## 関連タスク
<\!-- 関連するIssueやチケットのリンクを貼る。Issueの場合は、「#<IssueNumber>」でリンクできる -->

## やったこと
- `.github/configs/labeler.yml`に`claude`ラベルの設定を追加
- `.claude/**`ディレクトリ内のファイル変更時に自動で`claude`ラベルが付与される設定

## やらないこと
- 既存のlabeler設定の変更
- 手動でのラベル付与機能

## 影響範囲
- GitHub ActionsのPR Labeler機能への追加設定のみ
- 既存の`github-action`ラベルへの影響なし

## テスト
- 設定ファイルの構文確認済み
- `.claude/**`パスパターンの妥当性確認済み

## 備考
今後、Claude関連ファイルの変更があるPRには自動で`claude`ラベルが付与されます。