### PR TITLE
ga: slack通知

### DIFF
--- a/.github/workflows/slack-notification.yml
+++ b/.github/workflows/slack-notification.yml
@@ -1,0 +1,48 @@
+name: "GitHub Actions Notifications"
+
+on:
+  push:
+    branches:
+      - master
+  workflow_dispatch:
+
+jobs:
+  notify-slack:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.client_payload.git.ref == 'master' }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Debug PR Info
+        run: |
+          echo "PR Info: "
+          echo "URL: ${{ github.event.pull_request.html_url) }}"
+          echo "タイトル: ${{ github.event.pull_request.title) }}"
+          echo "本文: ${{ github.event.pull_request.body) }}"
+          echo "PR番号: ${{ github.event.pull_request.number) }}"
+          echo "openかclosedか: ${{ github.event.pull_request.state) }}"
+          echo "作成日時: ${{ github.event.pull_request.created_at) }}"
+          echo "プルリクを開いているブランチ: ${{ github.event.pull_request.head.ref) }}"
+          echo "プルリクのマージ先: ${{ github.event.pull_request.base.ref) }}"
+          echo "ドラフトかどうか: ${{ github.event.pull_request.draft) }}"
+          echo "マージされたかどうか: ${{ github.event.pull_request.merged) }}"
+
+      - name: Send Slack notification
+        uses: slackapi/slack-github-action@v2.1.0
+        with:
+          webhook: ${{ secrets.SLACK_INCOMING_WEBHOOK_URL }}
+          webhook-type: incoming-webhook
+          payload: |
+            {
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "${{github.event.pull_request.title}}のリリースが完了しました！\n\n"
+                  }
+                }
+              ]
+            }

--- a/.github/workflows/slack-notification.yml
+++ b/.github/workflows/slack-notification.yml
@@ -18,16 +18,16 @@ jobs:
       - name: Debug PR Info
         run: |
           echo "PR Info: "
-          echo "URL: ${{ github.event.pull_request.html_url) }}"
-          echo "タイトル: ${{ github.event.pull_request.title) }}"
-          echo "本文: ${{ github.event.pull_request.body) }}"
-          echo "PR番号: ${{ github.event.pull_request.number) }}"
-          echo "openかclosedか: ${{ github.event.pull_request.state) }}"
-          echo "作成日時: ${{ github.event.pull_request.created_at) }}"
-          echo "プルリクを開いているブランチ: ${{ github.event.pull_request.head.ref) }}"
-          echo "プルリクのマージ先: ${{ github.event.pull_request.base.ref) }}"
-          echo "ドラフトかどうか: ${{ github.event.pull_request.draft) }}"
-          echo "マージされたかどうか: ${{ github.event.pull_request.merged) }}"
+          echo "URL: ${{ github.event.pull_request.html_url }}"
+          echo "タイトル: ${{ github.event.pull_request.title }}"
+          echo "本文: ${{ github.event.pull_request.body }}"
+          echo "PR番号: ${{ github.event.pull_request.number }}"
+          echo "openかclosedか: ${{ github.event.pull_request.state }}"
+          echo "作成日時: ${{ github.event.pull_request.created_at }}"
+          echo "プルリクを開いているブランチ: ${{ github.event.pull_request.head.ref }}"
+          echo "プルリクのマージ先: ${{ github.event.pull_request.base.ref }}"
+          echo "ドラフトかどうか: ${{ github.event.pull_request.draft }}"
+          echo "マージされたかどうか: ${{ github.event.pull_request.merged }}"
 
       - name: Send Slack notification
         uses: slackapi/slack-github-action@v2.1.0


### PR DESCRIPTION
## 概要
Slack通知ワークフロー追加
PRをmainに混ぜた時に通知される

## 関連タスク
<!-- 関連するIssueやチケットのリンクを貼る。Issueの場合は、「#<IssueNumber>」でリンクできる -->

## やったこと
以下を参考にslack appの `webhook url` を発行し、githubのリポジトリのsettingsで `New repository secret` を設定
https://www.cloudbuilders.jp/articles/4961/

## やらないこと
<!-- このPRでやらないことは何か？ -->

## 影響範囲
<!-- 影響を及ぼす範囲や他の機能への影響 -->

## テスト
<!-- テスト方法や結果 -->

## 備考
<!-- レビュワーへの伝達事項や残しておきたい情報 -->
